### PR TITLE
Fix getRecoveryDelegateDids for empty list

### DIFF
--- a/lib/muport.js
+++ b/lib/muport.js
@@ -96,9 +96,12 @@ var MuPort = function () {
       var _this = this;
 
       var toBuffer = true;
-      var dids = this.document.symEncryptedData.symEncDids.map(function (encDid) {
-        return bufferToDid(_this.keyring.symDecrypt(encDid.ciphertext, encDid.nonce, toBuffer));
-      });
+      var dids = [];
+      if (this.document.symEncryptedData.symEncDids != undefined) {
+        dids = this.document.symEncryptedData.symEncDids.map(function (encDid) {
+          return bufferToDid(_this.keyring.symDecrypt(encDid.ciphertext, encDid.nonce, toBuffer));
+        });
+      }
       return dids;
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muport-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create and use µPort identities",
   "main": "lib/muport.js",
   "directories": {

--- a/src/__test__/muport.test.js
+++ b/src/__test__/muport.test.js
@@ -63,4 +63,14 @@ describe('MuPort', () => {
     assert.deepEqual(didsFromRecovered, [id1.getDid(), id2.getDid(), id3.getDid()])
   })
 
+  it('returns an empty list of delegate DIDs', async () => {
+    const dids = id1.getRecoveryDelegateDids()
+    assert.equal(dids.length, 0)
+    
+    const didsFromRecovered = recoveredId4.getRecoveryDelegateDids()
+    assert.deepEqual(didsFromRecovered, [id1.getDid(), id2.getDid(), id3.getDid()])
+  })
+
+
+
 })

--- a/src/muport.js
+++ b/src/muport.js
@@ -36,9 +36,12 @@ class MuPort {
 
   getRecoveryDelegateDids () {
     const toBuffer = true
-    const dids = this.document.symEncryptedData.symEncDids.map( 
-      (encDid) => bufferToDid(this.keyring.symDecrypt(encDid.ciphertext, encDid.nonce, toBuffer))
-    )
+    let dids = []
+    if (this.document.symEncryptedData.symEncDids != undefined){
+      dids = this.document.symEncryptedData.symEncDids.map(
+        (encDid) => bufferToDid(this.keyring.symDecrypt(encDid.ciphertext, encDid.nonce, toBuffer))
+      )
+    }
     return dids
   }
 


### PR DESCRIPTION
Handle the case where we have no delegates. The function then returns an empty list.